### PR TITLE
Set Boards Manager URL preference for ESP8266 package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ all:
 	arduino --verify ${ARG} ${SRC_DIR}/${MAIN_FILE}
 
 deps:
+	arduino --pref boardsmanager.additional.urls="http://arduino.esp8266.com/stable/package_esp8266com_index.json" --save-prefs
 	arduino --install-boards esp8266:esp8266
 	arduino --install-library "ArduinoThread,ArduinoJson,ESP8266 Oled Driver for SSD1306 display,Brzo I2C"
 


### PR DESCRIPTION
This is required for Boards Manager installation of 3rd party hardware packages that are not in the official Arduino package index JSON file.

Fixes https://github.com/arduino/Arduino/issues/6982